### PR TITLE
docs: replace “&” by “and”

### DIFF
--- a/manuscript/introduction.md
+++ b/manuscript/introduction.md
@@ -80,7 +80,7 @@ A tool that is handy for quickly trying what DOM tree is produced for a piece of
 
 ## History of HTML parsers
 
-### SGML & early HTML
+### SGML and early HTML
 
 The earliest documentation on HTML, as far as I know, is [HyperText Mark-up Language](http://info.cern.ch/hypertext/WWW/MarkUp/MarkUp.html), from CERN, 1992 ([also hosted on w3.org](https://www.w3.org/History/19921103-hypertext/hypertext/WWW/MarkUp/MarkUp.html)). The first paragraph reads:
 
@@ -181,7 +181,7 @@ The HTML standard has the following note about the relationship to SGML:
 
 In 2000, before Netscape 6 was released, [Gecko had a parser mode](https://bugzilla.mozilla.org/show_bug.cgi?id=40190) called "Strict DTD" that enforced stricter rules for HTML for documents with certain doctypes. This was quickly found to be incompatible with existing web content, and was [removed](https://bugzilla.mozilla.org/show_bug.cgi?id=50070) only two months after the parser mode was turned on in beta.
 
-### XML & XHTML
+### XML and XHTML
 
 XML is, like SGML, a syntax framework for defining markup languages, and is a simplification of SGML. Unlike SGML, XML defined error handling – a syntax error must halt normal processing. It omitted many features of SGML, such as SHORTTAG and optional tags. This allowed for parsing documents without reading the DTD. DTDs were retained in XML to allow for validation, although better schema languages were developed later. In hindsight it would have been a good opportunity to drop DTD support from XML, as it complicates the parser quite a bit.
 
@@ -191,7 +191,7 @@ XHTML 1.0 is a reformulation of HTML 4.01 in XML. It has all the same features a
 
 Indeed, the HTML standard now specifies that `</br>` is to be parsed as `<br>`. The space before the slash was for compatibility with Netscape 4, which would parse `<br/>` as an element `br/` which is not a known HTML element.
 
-### Internet Explorer, Firefox, Safari & Opera
+### Internet Explorer, Firefox, Safari and Opera
 
 When the HTML parser was first specified [in 2006](http://ln.hixie.ch/?start=1137740632&count=1), Internet Explorer was at version 6.
 

--- a/manuscript/parser.md
+++ b/manuscript/parser.md
@@ -136,7 +136,7 @@ The possible tokens are: doctype, start tag, end tag, comment, character, and en
 
 * End-of-file has no properties.
 
-### Tags & text
+### Tags and text
 
 Let's walk through a simple example to see how the tokenizer works: how it switches states and what tokens are produced.
 
@@ -1676,7 +1676,7 @@ There's a nested `form`! And the "`D`" `Text` node is where we’d expect (child
 
 In `template`s, `form`s are parsed more like `div`s, and aren't using the form element pointer.
 
-### Tables & foster parenting
+### Tables and foster parenting
 
 > [\#HTMLQuiz](https://twitter.com/RReverser/status/736219152709472256) In which order will the numbers appear for such bad HTML?
 >
@@ -2263,7 +2263,7 @@ If you have something between the head end tag and the body start tag (where onl
         └── noscript
 ```
 
-When seeing an `a` start tag if there's an `a` element in the *list of active formatting elements* (see the {% ref "parser", "Active formatting elements & Noah's Ark" %} section), then it implies an `a` end tag before it, but this is a parse error; the `a` end tag is *not* optional. The following example has two a start tags (end tag is mistyped as a start tag):
+When seeing an `a` start tag if there's an `a` element in the *list of active formatting elements* (see the {% ref "parser", "Active formatting elements and Noah's Ark" %} section), then it implies an `a` end tag before it, but this is a parse error; the `a` end tag is *not* optional. The following example has two a start tags (end tag is mistyped as a start tag):
 
 ```html
 <p><a href="1108470371">Anchor Bar reportedly opening Las Vegas location<a>.
@@ -2354,7 +2354,7 @@ The "default" handling of misnested markup, which is used for unknown elements, 
 
 Other elements are slightly more complicated, such as the `b`, `i`, and `a` elements, which are so-called *formatting elements*.
 
-#### Active formatting elements & Noah's Ark
+#### Active formatting elements and Noah's Ark
 
 The *formatting elements* are are:
 

--- a/manuscript/preface.md
+++ b/manuscript/preface.md
@@ -78,6 +78,8 @@ Thanks to Mike Smith for providing a raw log from a validator instance for the {
 
 Thanks to Marcos Caceres, Sam Sneddon, Taylor Hunt, Mike Smith, Anne van Kesteren, Marie Staver, Ian Hickson, Mathias Bynens, Henri Sivonen, and Philip Jägenstedt for reviewing this book.
 
+Thanks to Jens Oliver Meiert for contributing fixes for this book.
+
 ## Contribute
 
 The source code for this book is [available on GitHub](https://github.com/zcorpan/html-parser-book/). This book and the source code is [licensed under CC-BY-4.0](https://github.com/zcorpan/html-parser-book/blob/main/LICENSE). Feel free to report issues, submit pull requests, fork, etc.! If you wish to make a translation or otherwise reuse the work, you are welcome to do so (as allowed by the license). Please report an issue, to avoid duplicate work and so I can help get you set up.


### PR DESCRIPTION
Closes https://github.com/zcorpan/html-parser-book/issues/48

Signed-off-by: Jens Oliver Meiert <jens@meiert.com>