### PR TITLE
Chrome 148 finally shipped the 2013 adoption agency change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ Single-page chapters are wrapped in `<section class="book-chapter" headingoffset
 
 Subject line, then at most one short paragraph. No multi-section bodies, no bullet list restating the diff: say what was wrong and why the change is right, and leave the rest to the diff. Roughly half the commits in this repo have no body at all, which is the right call for a typo or a link fix.
 
+When fixing a reported issue, skip the description and just say "Fixes #123.".
+
 A commit that touches `manuscript/` has its subject line posted to [@htmlparserbook](https://x.com/htmlparserbook), so subjects are public and should read on their own. Backticked code in a message is safe (it used to break the workflow, see `post-to-x.yml`).
 
 ## Other

--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,6 @@ Open issues and PRs as of 2026-09-09.
 ## Parser and spec content
 
 - #84 — Reader wants detail on special tags: what "namespace boundaries" meant in the 2008 whatwg post, why exactly `mi`/`mo`/`mn`/`ms`/`mtext` are MathML text integration points, and the rationale for the element set in "has an element in scope".
-- #66 — WebKit's AAA fix (WebKit/WebKit#3297) landed; update the implementation status in the adoption agency algorithm section. Related: `parser.md:2540` still says "as of October 2018 (TODO)" for the 2013 AAA change.
 - #45 — Document `document.execCommand` with `insertHTML` under "Other parser APIs" in `scripting.md`. The linked Trusted Types issue is also a case study for the security chapter.
 - #44 — Write something about declarative shadow DOM.
 - #37 — Add a section about XML declaration character encoding, near "Bogus comments".

--- a/manuscript/parser.md
+++ b/manuscript/parser.md
@@ -2537,7 +2537,7 @@ It is exactly the same as the `<em><p></em>` case above, that is, it also trigge
             └── a
 ```
 
-In July 2013, there was [a change to the AAA](https://github.com/whatwg/html/commit/22ce3c31d8054c154042fd07150318a99ecc3e1b). Before the change, content could sometimes end up in the "wrong" order (not matching source order). This change has been implemented in Firefox, but, as of October 2018 (TODO), has not been implemented in other browsers. Sad panda.
+In July 2013, there was [a change to the AAA](https://github.com/whatwg/html/commit/22ce3c31d8054c154042fd07150318a99ecc3e1b). Before the change, content could sometimes end up in the "wrong" order (not matching source order). The change removed the cap of three on the inner loop, and added a step that removes *node* from the *list of active formatting elements* once the inner loop has run more than three times. Bugs were filed on all three engines. Gecko [fixed it in 2014](https://bugzilla.mozilla.org/show_bug.cgi?id=901319), WebKit [took until 2022](https://bugs.webkit.org/show_bug.cgi?id=119478), and Chromium finally [fixed it in 2026](https://chromium-review.googlesource.com/c/chromium/src/+/7535115).
 
 TODO loop limits, marker.
 


### PR DESCRIPTION
Fixes #66.