### PR TITLE
Decide the X post from the diff, not the push payload

### DIFF
--- a/.github/workflows/post-to-x.yml
+++ b/.github/workflows/post-to-x.yml
@@ -13,25 +13,37 @@ concurrency:
   group: post-to-x
   cancel-in-progress: false
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   post:
     runs-on: ubuntu-latest
-    # The paths filter above only says that the push touched manuscript/,
-    # which can be true of a push whose head commit is an infra change. Check
-    # the commit that actually gets posted. Every path is preceded by a "|" so
-    # that the match can be anchored at the start of a path.
-    if: >-
-      github.event.head_commit != null &&
-      contains(format('|{0}|{1}|{2}|',
-        join(github.event.head_commit.added, '|'),
-        join(github.event.head_commit.modified, '|'),
-        join(github.event.head_commit.removed, '|')), '|manuscript/')
 
     steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      # The paths filter above only says that the push touched manuscript/,
+      # which can be true of a push whose head commit is an infra change, so
+      # check the commit that actually gets posted.
+      - name: Look for manuscript changes
+        id: manuscript
+        run: |
+          FILES=$(git show --name-only --format= HEAD)
+          echo "$FILES"
+
+          if echo "$FILES" | grep -q "^manuscript/"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing under manuscript/; not posting."
+          fi
+
       - name: Refresh X OAuth token
         id: x
+        if: steps.manuscript.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_VARIABLES_TOKEN }}
           CLIENT_ID: ${{ secrets.X_CLIENT_ID }}
@@ -64,6 +76,7 @@ jobs:
           echo "access_token=$ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Post to X
+        if: steps.manuscript.outputs.changed == 'true'
         env:
           # Never interpolate these into the script: a commit message is
           # attacker-controlled text, and backticks in one would otherwise run


### PR DESCRIPTION
The `if` expression skipped c7b1d59 even though it changed `parser.md`, and a skipped job leaves no log to debug. Replace it with a checkout and `git show --name-only`, which prints the file list it decided from.